### PR TITLE
Add node field for each Shape

### DIFF
--- a/src/core/application.rs
+++ b/src/core/application.rs
@@ -1,12 +1,9 @@
 use crate::textures::texture_img::load_texture_image;
-use crate::textures::utils::{TextureGen, TextureOrColor};
 use wasm_bindgen::prelude::*;
 use web_sys::{WebGl2RenderingContext, WebGlTexture};
 
-use crate::display::display_object::DisplayObject;
 use crate::graphics::{Container, Shape};
 use crate::math::Matrix;
-use crate::textures::solid_texture::create_solid_texture;
 
 #[wasm_bindgen]
 extern "C" {
@@ -69,22 +66,6 @@ impl Application {
 
     pub fn add_shape(&mut self, shape: &impl Shape) {
         self.stage.add_shape(shape);
-    }
-
-    pub fn draw_textured_shape<T: Shape>(&self, shape: &T, texture: &WebGlTexture) {
-        DisplayObject::new(&self.ctx, shape.get_geom()).draw_textured(&self.proj_mat, &texture);
-    }
-
-    pub fn draw_colored_shape<T: Shape>(&self, shape: &T, color: &Vec<u8>) {
-        self.draw_textured_shape(shape, &create_solid_texture(&self.ctx, color));
-    }
-
-    pub fn draw_shape<T: Shape, U: TextureGen>(&self, shape: &T, mask: &U) {
-        let temp = mask.to_enum();
-        match temp {
-            TextureOrColor::Color(color) => self.draw_colored_shape(shape, &color),
-            TextureOrColor::Texture(texture) => self.draw_textured_shape(shape, &texture),
-        }
     }
 
     pub fn tex_from_img(&self, src: &str) -> WebGlTexture {

--- a/src/display/attribs.rs
+++ b/src/display/attribs.rs
@@ -2,7 +2,6 @@ use crate::display::shader_program::ShaderProgram;
 use crate::graphics::geom::Geom;
 use crate::shaders::ShaderConstant;
 use crate::utils::gl_utils::{bind_f32_buffer_data, bind_u8_buffer_data, create_array_buffer};
-use std::cell::Ref;
 use web_sys::{WebGl2RenderingContext, WebGlBuffer, WebGlTexture};
 
 #[derive(Debug, Clone)]
@@ -12,7 +11,7 @@ pub struct Attrib {
 }
 
 impl Attrib {
-    pub fn from_f32(ctx: &WebGl2RenderingContext, data: &Vec<f32>, num_components: i32) -> Self {
+    pub fn from_f32(ctx: &WebGl2RenderingContext, data: &[f32], num_components: i32) -> Self {
         let buffer = create_array_buffer(ctx);
 
         bind_f32_buffer_data(ctx, data);
@@ -23,7 +22,7 @@ impl Attrib {
         }
     }
 
-    pub fn from_u8(ctx: &WebGl2RenderingContext, data: &Vec<u8>, num_components: i32) -> Self {
+    pub fn from_u8(ctx: &WebGl2RenderingContext, data: &[u8], num_components: i32) -> Self {
         let buffer = create_array_buffer(ctx);
 
         bind_u8_buffer_data(ctx, data);
@@ -79,7 +78,7 @@ pub struct Attribs {
 }
 
 impl Attribs {
-    pub fn new(ctx: &WebGl2RenderingContext, g: Ref<Geom>) -> Self {
+    pub fn new(ctx: &WebGl2RenderingContext, g: &Geom) -> Self {
         let position = Attrib::from_f32(ctx, &g.vertices, 2);
         let texture_coords = Attrib::from_f32(ctx, &g.tex_coords, 2);
         // let color = Attrib::from_texture(ctx, &g.texture, 2);

--- a/src/graphics/container.rs
+++ b/src/graphics/container.rs
@@ -1,10 +1,10 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use crate::core::application::Application;
 use crate::graphics::scene_graph::GraphNode;
 use crate::math::Matrix;
 
-use super::{Geom, Shape};
+use super::{scene_graph::GraphEntity, Shape};
 
 pub struct Container {
     pub node: Rc<RefCell<GraphNode>>,
@@ -24,17 +24,7 @@ impl Container {
     }
 
     pub fn add_shape(&mut self, shape: &impl Shape) {
-        let node = GraphNode {
-            is_leaf: true,
-            geom: shape.get_geom(),
-            children: Vec::new(),
-            idx_map: HashMap::new(),
-        };
-
-        self.node
-            .borrow_mut()
-            .add_child(Rc::new(RefCell::new(node)));
-
+        self.node.borrow_mut().add_child(shape.get_node());
         shape.update_parent(Some(self.node.clone()));
     }
 
@@ -56,9 +46,11 @@ impl Container {
     }
 }
 
-// `Shape` would be a misnomer here. Vector Space/Coord System would be better
-impl Shape for Container {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.node.borrow().geom.clone()
+impl GraphEntity for Container {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
+
+// `Shape` would be a misnomer here. Vector Space/Coord System would be better
+impl Shape for Container {}

--- a/src/graphics/geom/geom.rs
+++ b/src/graphics/geom/geom.rs
@@ -1,17 +1,13 @@
 use web_sys::WebGl2RenderingContext;
 
 use crate::{
-    graphics::{scene_graph::GraphNode, shapes::utils::calc_n_vertices},
+    graphics::shapes::utils::calc_n_vertices,
     math::Matrix,
     textures::utils::{TextureGen, TextureOrColor},
 };
-use std::{cell::RefCell, rc::Rc};
-use uuid::Uuid;
 
+#[derive(Debug, Clone)]
 pub struct Geom {
-    pub id: Uuid,
-    pub parent: Option<Rc<RefCell<GraphNode>>>,
-
     pub vertices: Vec<f32>,   // vertex data
     pub tex_coords: Vec<f32>, // texture vertices
     pub texture_data: TextureOrColor,
@@ -23,8 +19,6 @@ pub struct Geom {
 impl Default for Geom {
     fn default() -> Self {
         Geom {
-            id: Uuid::new_v4(),
-            parent: None,
             vertices: Vec::new(),
             tex_coords: Vec::new(),
             u_mat: Matrix::new(),
@@ -47,8 +41,6 @@ impl Geom {
         let texture_data = mask.to_enum();
 
         Geom {
-            id: Uuid::new_v4(),
-            parent: None,
             vertices: vertices.to_vec(),
             tex_coords,
             u_mat,
@@ -65,28 +57,20 @@ impl Geom {
         height: f32,
         no_sides: usize,
         color_or_texture: &impl TextureGen,
-    ) -> Rc<RefCell<Geom>> {
+    ) -> Geom {
         let vertices = calc_n_vertices(width, height, no_sides);
 
-        Rc::new(RefCell::new(Geom::new(
+        Geom::new(
             &vertices,
             Matrix::translation(x, y),
             WebGl2RenderingContext::TRIANGLE_FAN,
             no_sides as i32,
             color_or_texture,
-        )))
+        )
     }
 
     pub fn set_texture(&mut self, text_gen: &impl TextureGen) {
         self.texture_data = text_gen.to_enum();
-    }
-
-    pub fn update_parent(&mut self, node: Option<Rc<RefCell<GraphNode>>>) {
-        if let Some(p) = &self.parent {
-            p.borrow_mut().remove_child(self.id);
-        }
-
-        self.parent = node;
     }
 
     pub fn rotate(&mut self, angle: f32) {

--- a/src/graphics/shapes/circle.rs
+++ b/src/graphics/shapes/circle.rs
@@ -1,3 +1,4 @@
+use crate::graphics::scene_graph::{GraphEntity, GraphNode};
 use crate::graphics::{shapes::Rectangle, Geom, Shape};
 use crate::math::bounding_rect::Bounded;
 use crate::textures::utils::TextureGen;
@@ -7,7 +8,7 @@ use std::rc::Rc;
 pub struct Circle {
     pub radius: f32,
 
-    geom: Rc<RefCell<Geom>>,
+    node: Rc<RefCell<GraphNode>>,
 }
 
 impl Circle {
@@ -15,7 +16,9 @@ impl Circle {
         let vertex_count = 200;
         let geom = Geom::build_geom(x, y, radius, radius, vertex_count, color_or_texture);
 
-        Circle { radius, geom }
+        let node = GraphNode::for_shape(geom);
+
+        Circle { radius, node }
     }
 
     pub fn new_at_origin(radius: f32, color_or_texture: &impl TextureGen) -> Self {
@@ -23,15 +26,17 @@ impl Circle {
     }
 }
 
-impl Shape for Circle {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.geom.clone()
+impl GraphEntity for Circle {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
 
+impl Shape for Circle {}
+
 impl Bounded for Circle {
     fn contains(&self, x: f32, y: f32) -> bool {
-        let (x_p, y_p) = self.geom.borrow().u_mat.inverse_affine_point(x, y);
+        let (x_p, y_p) = self.node.borrow().geom.u_mat.inverse_affine_point(x, y);
 
         match self.radius {
             r2 if r2 <= 0.0 => false,

--- a/src/graphics/shapes/ellipse.rs
+++ b/src/graphics/shapes/ellipse.rs
@@ -1,14 +1,14 @@
+use crate::graphics::scene_graph::{GraphEntity, GraphNode};
 use crate::graphics::{shapes::Rectangle, Geom, Shape};
 use crate::math::bounding_rect::Bounded;
 use crate::textures::utils::TextureGen;
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 pub struct Ellipse {
     pub width: f32,  // center to horizontal edge
     pub height: f32, // center to horizontal edge
 
-    geom: Rc<RefCell<Geom>>,
+    node: Rc<RefCell<GraphNode>>,
 }
 
 impl Ellipse {
@@ -21,11 +21,12 @@ impl Ellipse {
     ) -> Self {
         let vertex_count = 200;
         let geom = Geom::build_geom(x, y, width, height, vertex_count, color_or_texture);
+        let node = GraphNode::for_shape(geom);
 
         Ellipse {
             width,
             height,
-            geom,
+            node,
         }
     }
 
@@ -34,16 +35,18 @@ impl Ellipse {
     }
 }
 
-impl Shape for Ellipse {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.geom.clone()
+impl GraphEntity for Ellipse {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
+
+impl Shape for Ellipse {}
 
 impl Bounded for Ellipse {
     // https://math.stackexchange.com/a/76463/525170
     fn contains(&self, x: f32, y: f32) -> bool {
-        let (x_p, y_p) = self.geom.borrow().u_mat.inverse_affine_point(x, y);
+        let (x_p, y_p) = self.node.borrow().geom.u_mat.inverse_affine_point(x, y);
 
         match (self.width, self.height) {
             t if t.0 <= 0.0 || t.1 <= 0.0 => false,

--- a/src/graphics/shapes/polygon.rs
+++ b/src/graphics/shapes/polygon.rs
@@ -1,20 +1,23 @@
+use crate::graphics::scene_graph::{GraphEntity, GraphNode};
 use crate::graphics::{Geom, Shape};
 use crate::math::bounding_rect::Bounded;
 use crate::textures::utils::TextureGen;
-use std::cell::RefCell;
-use std::rc::Rc;
+
+use std::{cell::RefCell, rc::Rc};
 
 pub struct RegularPolygon {
     pub radius: f32,
     pub sides: usize,
-    geom: Rc<RefCell<Geom>>,
+
+    node: Rc<RefCell<GraphNode>>,
 }
 
 pub struct IrregularPolygon {
     pub width: f32,
     pub height: f32,
     pub sides: usize,
-    geom: Rc<RefCell<Geom>>,
+
+    node: Rc<RefCell<GraphNode>>,
 }
 
 impl RegularPolygon {
@@ -27,11 +30,12 @@ impl RegularPolygon {
     ) -> Self {
         let sides = n_sides.max(3);
         let geom = Geom::build_geom(x, y, radius, radius, sides, color_or_texture);
+        let node = GraphNode::for_shape(geom);
 
         RegularPolygon {
             radius,
             sides,
-            geom,
+            node,
         }
     }
 
@@ -40,11 +44,13 @@ impl RegularPolygon {
     }
 }
 
-impl Shape for RegularPolygon {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.geom.clone()
+impl GraphEntity for RegularPolygon {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
+
+impl Shape for RegularPolygon {}
 
 impl Bounded for RegularPolygon {}
 
@@ -59,12 +65,13 @@ impl IrregularPolygon {
     ) -> Self {
         let sides = n_sides.max(3);
         let geom = Geom::build_geom(x, y, width, height, sides, color_or_texture);
+        let node = GraphNode::for_shape(geom);
 
         IrregularPolygon {
             width,
             height,
             sides,
-            geom,
+            node,
         }
     }
 
@@ -92,12 +99,13 @@ impl IrregularPolygon {
             - ys.iter().cloned().fold(f32::NAN, f32::min);
 
         let geom = Geom::build_geom(0.0, 0.0, width, height, sides, color_or_texture);
+        let node = GraphNode::for_shape(geom);
 
         IrregularPolygon {
             width,
             height,
             sides,
-            geom,
+            node,
         }
     }
 
@@ -111,10 +119,12 @@ impl IrregularPolygon {
     }
 }
 
-impl Shape for IrregularPolygon {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.geom.clone()
+impl GraphEntity for IrregularPolygon {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
+
+impl Shape for IrregularPolygon {}
 
 impl Bounded for IrregularPolygon {}

--- a/src/graphics/shapes/quad.rs
+++ b/src/graphics/shapes/quad.rs
@@ -1,5 +1,5 @@
-use std::cell::RefCell;
-use std::rc::Rc;
+use crate::graphics::scene_graph::{GraphEntity, GraphNode};
+use std::{cell::RefCell, rc::Rc};
 
 use web_sys::WebGl2RenderingContext;
 
@@ -12,7 +12,7 @@ pub struct Rectangle {
     pub width: f32,
     pub height: f32,
 
-    geom: Rc<RefCell<Geom>>,
+    node: Rc<RefCell<GraphNode>>,
 }
 
 impl Rectangle {
@@ -38,10 +38,12 @@ impl Rectangle {
             color_or_texture,
         );
 
+        let node = GraphNode::for_shape(geom);
+
         Rectangle {
             width,
             height,
-            geom: Rc::new(RefCell::new(geom)),
+            node,
         }
     }
 
@@ -50,7 +52,7 @@ impl Rectangle {
     }
 
     pub fn contains(&self, x: f32, y: f32) -> bool {
-        let (x_p, y_p) = self.geom.borrow().u_mat.inverse_affine_point(x, y);
+        let (x_p, y_p) = self.node.borrow().geom.u_mat.inverse_affine_point(x, y);
 
         match (self.width, self.height) {
             t if t.0 <= 0.0 || t.1 <= 0.0 => false,
@@ -60,11 +62,13 @@ impl Rectangle {
     }
 }
 
-impl Shape for Rectangle {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.geom.clone()
+impl GraphEntity for Rectangle {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
+
+impl Shape for Rectangle {}
 
 impl Bounded for Rectangle {
     fn get_bounding_rect_inner(&self) -> Rectangle {

--- a/src/graphics/shapes/shape.rs
+++ b/src/graphics/shapes/shape.rs
@@ -1,95 +1,76 @@
-use crate::graphics::scene_graph::GraphNode;
-use crate::graphics::Geom;
+use crate::graphics::scene_graph::{GraphEntity, GraphNode};
 use crate::math::Matrix;
 use crate::textures::utils::TextureGen;
 use std::cell::RefCell;
 use std::rc::Rc;
-use uuid::Uuid;
 
-pub trait Shape {
-    fn get_geom(&self) -> Rc<RefCell<Geom>>;
-
-    fn get_id(&self) -> uuid::Uuid {
-        self.get_geom().borrow().id
-    }
-
-    fn get_parent(&self) -> Option<Rc<RefCell<GraphNode>>> {
-        self.get_geom().borrow().parent.clone()
-    }
-
-    fn get_parent_id(&self) -> Option<Uuid> {
-        let parent = self.get_geom().borrow().parent.clone();
-
-        parent.map(|p| p.borrow().get_id())
-    }
-
-    fn update_parent(&self, node: Option<Rc<RefCell<GraphNode>>>) {
-        self.get_geom().borrow_mut().update_parent(node)
+pub trait Shape: GraphEntity {
+    fn get_model_matrix(&self) -> Matrix {
+        self.get_node().borrow().geom.u_mat.clone()
     }
 
     fn get_final_transformation_matrix(&self) -> Matrix {
-        let mut mat = self.get_geom().borrow().u_mat.clone();
-
-        if let Some(p) = &self.get_parent() {
-            let mat2 = p.borrow().get_final_transformation_matrix();
-            mat.mul_inplace(&mat2);
-        }
-
-        mat
+        self.get_node()
+            .borrow_mut()
+            .get_final_transformation_matrix()
     }
 
     fn apply_transformations(&self, tranformation_mat: &Matrix) {
-        self.get_geom().borrow_mut().u_mat = tranformation_mat.clone();
+        self.get_node().borrow_mut().geom.u_mat = tranformation_mat.clone();
     }
 
-    fn copy_transformations_from_geom(&self, geom: Rc<RefCell<Geom>>) {
-        self.get_geom().borrow_mut().u_mat = geom.borrow().u_mat.clone();
+    fn copy_transformations_from_node(&self, node: Rc<RefCell<GraphNode>>) {
+        self.get_node().borrow_mut().geom.u_mat = node.borrow().geom.u_mat.clone();
     }
 
     fn copy_transformations(&self, other_shape: &impl Shape) {
-        self.get_geom().borrow_mut().u_mat = other_shape.get_geom().borrow().u_mat.clone();
+        self.get_node().borrow_mut().geom.u_mat =
+            other_shape.get_node().borrow().geom.u_mat.clone();
     }
 
     fn set_texture(&self, text_gen: &impl TextureGen) {
-        self.get_geom().borrow_mut().set_texture(text_gen);
+        self.get_node().borrow_mut().geom.set_texture(text_gen);
     }
 
     // This center is not the absolute, rather relative to its parent's center
     fn get_center(&self) -> (f32, f32) {
-        let mat = self.get_geom().borrow().u_mat.clone();
+        let mat = self.get_node().borrow().geom.u_mat.clone();
 
         (mat.tx, mat.ty)
     }
 
     // Transformation funcs
     fn rotate(&self, angle_radians: f32) {
-        let geom = self.get_geom();
-        geom.borrow_mut().rotate(angle_radians);
+        self.get_node().borrow_mut().geom.rotate(angle_radians);
     }
 
     fn rotate_deg(&self, angle_degrees: f32) {
-        self.rotate(angle_degrees.to_radians());
+        self.get_node()
+            .borrow_mut()
+            .geom
+            .rotate(angle_degrees.to_radians());
     }
 
     fn translate(&self, tx: f32, ty: f32) {
-        let geom = self.get_geom();
-        geom.borrow_mut().translate(tx, ty);
+        self.get_node().borrow_mut().geom.translate(tx, ty);
     }
 
     fn scale(&self, x: f32, y: f32) {
-        let geom = self.get_geom();
-        geom.borrow_mut().scale(x, y);
+        self.get_node().borrow_mut().geom.scale(x, y);
     }
 
     // Move by tx,ty offset relative to the current position
     fn move_by(&self, tx: f32, ty: f32) {
-        self.translate(tx, ty);
+        self.get_node().borrow_mut().geom.translate(tx, ty);
     }
 
     // Move to tx,ty position relative to the parent container's center
     fn move_to(&self, new_x: f32, new_y: f32) {
         let (center_x, center_y) = self.get_center();
 
-        self.translate(new_x - center_x, new_y - center_y);
+        self.get_node()
+            .borrow_mut()
+            .geom
+            .translate(new_x - center_x, new_y - center_y);
     }
 }

--- a/src/graphics/shapes/triangle.rs
+++ b/src/graphics/shapes/triangle.rs
@@ -1,3 +1,4 @@
+use crate::graphics::scene_graph::{GraphEntity, GraphNode};
 use crate::math::bounding_rect::Bounded;
 use std::{cell::RefCell, rc::Rc};
 use web_sys::WebGl2RenderingContext;
@@ -8,7 +9,8 @@ use crate::textures::utils::TextureGen;
 
 pub struct Triangle {
     pub size: f32,
-    geom: Rc<RefCell<Geom>>,
+
+    node: Rc<RefCell<GraphNode>>,
 }
 
 impl Triangle {
@@ -20,15 +22,17 @@ impl Triangle {
 
         let vertices = [left, top, right, top, left, bottom].to_vec();
 
-        let geom = Rc::new(RefCell::new(Geom::new(
+        let geom = Geom::new(
             &vertices,
             Matrix::translation(x, y),
             WebGl2RenderingContext::TRIANGLES,
             3,
             color_or_texture,
-        )));
+        );
 
-        Triangle { size, geom }
+        let node = GraphNode::for_shape(geom);
+
+        Triangle { size, node }
     }
 
     pub fn new_at_origin(size: f32, color_or_texture: &impl TextureGen) -> Self {
@@ -36,10 +40,12 @@ impl Triangle {
     }
 }
 
-impl Shape for Triangle {
-    fn get_geom(&self) -> Rc<RefCell<Geom>> {
-        self.geom.clone()
+impl GraphEntity for Triangle {
+    fn get_node(&self) -> Rc<RefCell<GraphNode>> {
+        self.node.clone()
     }
 }
+
+impl Shape for Triangle {}
 
 impl Bounded for Triangle {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub fn main() -> Result<(), JsValue> {
     app.add_container(&container);
     app.add_container(&container_2);
 
-    container.rotate_deg(5.0);
+    c.rotate_deg(5.0);
     c.move_by(10.0, 10.0);
     c.scale(1.1, 1.1);
 
@@ -88,7 +88,7 @@ pub fn main() -> Result<(), JsValue> {
 
     let p = (180.0, 150.0);
     console_log!("Point: {:?}", p);
-    let p_inv = c.get_geom().borrow().u_mat.inverse_affine_point(p.0, p.1);
+    let p_inv = c.get_model_matrix().inverse_affine_point(p.0, p.1);
     console_log!("Inv Point: {:?}", p_inv);
     console_log!(
         "Contains in bounds (false): {:?}",
@@ -97,7 +97,7 @@ pub fn main() -> Result<(), JsValue> {
 
     let p = (120.0, 150.0);
     console_log!("Point: {:?}", p);
-    let p_inv = c.get_geom().borrow().u_mat.inverse_affine_point(p.0, p.1);
+    let p_inv = c.get_model_matrix().inverse_affine_point(p.0, p.1);
     console_log!("Inv Point: {:?}", p_inv);
     console_log!("Contains(false): {:?}", c.contains(p.0, p.1)); // should be false
     console_log!(
@@ -107,7 +107,7 @@ pub fn main() -> Result<(), JsValue> {
 
     let p = (90.0, 30.0);
     console_log!("Point: {:?}", p);
-    let p_inv = c.get_geom().borrow().u_mat.inverse_affine_point(p.0, p.1);
+    let p_inv = c.get_model_matrix().inverse_affine_point(p.0, p.1);
     console_log!("Inv Point: {:?}", p_inv);
     console_log!("Contains(true): {:?}", c.contains(p.0, p.1)); // should be true
 
@@ -121,6 +121,17 @@ pub fn main() -> Result<(), JsValue> {
 
     container_2.add_shape(&c_bound_normal);
     container_2.add_shape(&c_normal);
+
+    let final_mat_c = c.get_final_transformation_matrix();
+    let mut other_mat = Matrix::new();
+
+    let mut other_mat = other_mat.rotate((5.0_f32).to_radians());
+    other_mat.translate_inplace(10.0, 10.0);
+    other_mat.scale_inplace(1.1, 1.1);
+
+    console_log!("Expected mat: {:?}", other_mat);
+
+    console_log!("Actual mat: {:?}", final_mat_c);
 
     render_loop(move || {
         app.render();

--- a/src/math/bounding_rect.rs
+++ b/src/math/bounding_rect.rs
@@ -1,12 +1,14 @@
 use crate::graphics::{shapes::Rectangle, Shape};
+
 pub trait Bounded: Shape {
     // Expects vertices in counter clockwise direction
     fn contains(&self, x: f32, y: f32) -> bool {
         let transform_mat = self.get_final_transformation_matrix();
         let (x_p, y_p) = transform_mat.inverse_affine_point(x, y);
 
-        self.get_geom()
+        self.get_node()
             .borrow()
+            .geom
             .vertices
             .chunks_exact(2)
             .map(|c| (c[0], c[1]))
@@ -34,8 +36,9 @@ pub trait Bounded: Shape {
         let mut max_x = f32::MIN;
         let mut max_y = f32::MIN;
 
-        self.get_geom()
+        self.get_node()
             .borrow()
+            .geom
             .vertices
             .chunks_exact(2)
             .for_each(|chunk| {
@@ -57,7 +60,7 @@ pub trait Bounded: Shape {
     // Get the bounding rectangle with the transformations applied
     fn get_bounds(&self) -> Rectangle {
         let rect = self.get_bounding_rect_inner();
-        rect.copy_transformations_from_geom(self.get_geom());
+        rect.apply_transformations(&self.get_node().borrow().geom.u_mat);
 
         rect
     }

--- a/src/textures/utils.rs
+++ b/src/textures/utils.rs
@@ -1,5 +1,6 @@
 use web_sys::WebGlTexture;
 
+#[derive(Debug, Clone)]
 pub enum TextureOrColor {
     Texture(WebGlTexture),
     Color(Vec<u8>),

--- a/src/utils/gl_utils.rs
+++ b/src/utils/gl_utils.rs
@@ -15,9 +15,9 @@ pub fn create_array_buffer(ctx: &WebGl2RenderingContext) -> WebGlBuffer {
     create_buffer_with_type(ctx, WebGl2RenderingContext::ARRAY_BUFFER)
 }
 
-pub fn bind_f32_buffer_data(ctx: &WebGl2RenderingContext, data: &Vec<f32>) {
+pub fn bind_f32_buffer_data(ctx: &WebGl2RenderingContext, data: &[f32]) {
     unsafe {
-        let view = js_sys::Float32Array::view(data.as_slice());
+        let view = js_sys::Float32Array::view(data);
         ctx.buffer_data_with_array_buffer_view(
             WebGl2RenderingContext::ARRAY_BUFFER,
             &view,
@@ -26,9 +26,9 @@ pub fn bind_f32_buffer_data(ctx: &WebGl2RenderingContext, data: &Vec<f32>) {
     };
 }
 
-pub fn bind_u8_buffer_data(ctx: &WebGl2RenderingContext, data: &Vec<u8>) {
+pub fn bind_u8_buffer_data(ctx: &WebGl2RenderingContext, data: &[u8]) {
     unsafe {
-        let view = js_sys::Uint8Array::view(data.as_slice());
+        let view = js_sys::Uint8Array::view(data);
         ctx.buffer_data_with_array_buffer_view(
             WebGl2RenderingContext::ARRAY_BUFFER,
             &view,


### PR DESCRIPTION
- A ref to a GraphNode is stored inside each GraphEntity, which is required for each Shape
- Inside the node, geom is stored without using Rc and RefCell
- This makes the interface cleaner, as Geom now stores only the graphics related data